### PR TITLE
poc: create product field nodes

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,6 +1,76 @@
+// @ts-check
 exports.onCreateBabelConfig = ({ actions }) => {
   actions.setBabelPlugin({
     name: `babel-plugin-react-icons`,
     options: {},
   })
+}
+
+exports.unstable_shouldOnCreateNode = ({ node }) =>
+  node.internal.type === `ShopifyProduct`
+
+function createOrphanNode({
+  createNode,
+  createContentDigest,
+  getNode,
+  type,
+  value,
+  createNodeId,
+}) {
+  const id = createNodeId(`${type}-${value}`)
+
+  if (getNode(id)) {
+    return
+  }
+  const node = {
+    id,
+    name: value,
+    internal: {
+      type,
+      contentDigest: createContentDigest(value),
+    },
+  }
+  createNode(node)
+}
+
+exports.onCreateNode = ({
+  node,
+  actions,
+  createContentDigest,
+  getNode,
+  createNodeId,
+}) => {
+  const { createNode } = actions
+  if (node.vendor) {
+    createOrphanNode({
+      type: 'ShopifyVendor',
+      value: node.vendor,
+      createNode,
+      createContentDigest,
+      createNodeId,
+      getNode,
+    })
+  }
+
+  if (node.productType) {
+    createOrphanNode({
+      type: 'ShopifyProductType',
+      value: node.productType,
+      createNode,
+      createContentDigest,
+      createNodeId,
+      getNode,
+    })
+  }
+
+  node.tags?.forEach((tag) =>
+    createOrphanNode({
+      type: 'ShopifyTag',
+      value: tag,
+      createNode,
+      createContentDigest,
+      createNodeId,
+      getNode,
+    })
+  )
 }


### PR DESCRIPTION
This is mostly a demo to show the creation of nodes for `tag`, `vendor` and `productType`. We should **not** ship anything like this to production. It is not efficient, and we shouldn't be shipping stuff in gatsby-node in the starter. If we're happy with the idea, we should implement it properly in the source plugin.