### PR TITLE
Add pagination

### DIFF
--- a/src/components/check-filter.jsx
+++ b/src/components/check-filter.jsx
@@ -6,13 +6,11 @@ export function CheckFilter({
   selectedItems = [],
   setSelectedItems,
   open = true,
-  onFilter,
 }) {
   const toggleItem = ({ currentTarget: input }) => {
     if (input.checked) {
       setSelectedItems((items) => {
         const newItems = [...items, input.value]
-        onFilter(newItems, name)
         return newItems
       })
     } else {
@@ -22,7 +20,6 @@ export function CheckFilter({
           return
         }
         const newItems = [...items.slice(0, idx), ...items.slice(idx + 1)]
-        onFilter(newItems, name)
         return newItems
       })
     }

--- a/src/pages/products/index.jsx
+++ b/src/pages/products/index.jsx
@@ -21,7 +21,10 @@ export default Products
 
 export const query = graphql`
   {
-    products: allShopifyProduct(sort: { fields: publishedAt, order: ASC }) {
+    products: allShopifyProduct(
+      sort: { fields: publishedAt, order: ASC }
+      limit: 100
+    ) {
       nodes {
         ...ProductCard
       }

--- a/src/pages/search-page.module.css
+++ b/src/pages/search-page.module.css
@@ -83,6 +83,8 @@
   height: var(--size-2xl);
   font-size: var(--text-sm);
   border-radius: var(--border-radius-sm);
+  display: grid;
+  place-items: center;
 }
 
 .pagination > button:hover {

--- a/src/pages/search-page.module.css
+++ b/src/pages/search-page.module.css
@@ -71,3 +71,30 @@
   justify-content: center;
   width: 100%;
 }
+
+.pagination {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+}
+
+.pagination > button {
+  width: var(--size-2xl);
+  height: var(--size-2xl);
+  font-size: var(--text-sm);
+  border-radius: var(--border-radius-sm);
+}
+
+.pagination > button:hover {
+  background-color: var(--black-fade-10);
+}
+
+.pagination > button.selectedItem {
+  background-color: var(--black-fade-10);
+  font-weight: 700;
+}
+
+.pagination > button:disabled {
+  cursor: default;
+  opacity: 0;
+}

--- a/src/pages/search.jsx
+++ b/src/pages/search.jsx
@@ -124,8 +124,15 @@ const SearchPage = ({
     }
   }, [selectedTags, selectedProductTypes, selectedVendors, sortKey, searchTerm])
 
-  const productList =
-    (!data?.products?.edges ? products.edges : data?.products?.edges) || []
+  const isDefault =
+    selectedTags.length === tags.length &&
+    selectedProductTypes.length === productTypes.length &&
+    selectedVendors.length === vendors.length &&
+    !searchTerm &&
+    !sortKey &&
+    cursor === -1
+
+  const productList = (isDefault ? products.edges : data?.products?.edges) || []
 
   return (
     <Layout>

--- a/src/pages/search.jsx
+++ b/src/pages/search.jsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { useLocation } from '@reach/router'
 import { graphql } from 'gatsby'
 import slugify from 'slugify'
-import { CgSearch } from 'react-icons/cg'
+import { CgSearch, CgChevronRight, CgChevronLeft } from 'react-icons/cg'
 import Layout from '../components/layout'
 import { CheckFilter } from '../components/check-filter'
 import ProductCard from '../components/product-card'
@@ -204,7 +204,7 @@ const SearchPage = ({
                 onClick={() => setCursor(cursor - 1)}
                 aria-label="Previous page"
               >
-                &lt;
+                <CgChevronLeft />
               </button>
               <button
                 onClick={() => setCursor(-1)}
@@ -228,7 +228,7 @@ const SearchPage = ({
                 onClick={() => setCursor(cursor + 1)}
                 aria-label="Next page"
               >
-                &gt;
+                <CgChevronRight />
               </button>
             </nav>
           )}

--- a/src/pages/search.jsx
+++ b/src/pages/search.jsx
@@ -43,9 +43,7 @@ const SearchPage = ({
 
   const [searchTerm, setSearchTerm] = React.useState(queryParams.term)
 
-  const [sortKey, setSortKey] = React.useState(
-    queryParams.sortKey ?? `RELEVANCE`
-  )
+  const [sortKey, setSortKey] = React.useState(queryParams.sortKey)
 
   const [selectedTags, setSelectedTags] = React.useState(
     queryParams.tags || tags
@@ -109,10 +107,11 @@ const SearchPage = ({
               value={sortKey}
               onChange={(e) => setSortKey(e.target.value)}
             >
-              <option value="PRICE">Price</option>
               <option value="RELEVANCE">Relevance</option>
+              <option value="PRICE">Price</option>
               <option value="TITLE">Title</option>
-              <option value="VENDOR">Vendor</option>
+              <option value="CREATED_AT">New items</option>
+              <option value="BEST_SELLING">Trending</option>
             </select>
           </div>
         </div>
@@ -169,11 +168,11 @@ const SearchPage = ({
             </button>
             <button
               onClick={() => setCursor(-1)}
-              className={cursor === -1 && selectedItem}
+              className={cursor === -1 ? selectedItem : undefined}
             >
               1
             </button>
-            {pages.map((page, index) => (
+            {pages.map((_, index) => (
               <button
                 onClick={() => setCursor(index)}
                 className={index === cursor ? selectedItem : undefined}

--- a/src/pages/search.jsx
+++ b/src/pages/search.jsx
@@ -80,7 +80,12 @@ const SearchPage = ({
   React.useEffect(() => {
     if (cursor === pages.length - 1 && data?.products?.pageInfo?.hasNextPage) {
       setPages(
-        Array.from(new Set([...pages, data?.products?.edges?.[0]?.cursor]))
+        Array.from(
+          new Set([
+            ...pages,
+            data?.products?.edges?.[data.products.edges.length - 1]?.cursor,
+          ])
+        )
       )
     }
     if (data?.products?.pageInfo && !data.products.pageInfo.hasNextPage) {

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -5,6 +5,7 @@
   --black-fade-5: #eeeeee;
   --blue-hover: #4299e199;
   --border-radius: 8px;
+  --border-radius-sm: 4px;
   --size-sm: 4px;
   --size-md: 8px;
   --size-lg: 16px;

--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -3,39 +3,51 @@ import { useEffect, useState } from 'react'
 import { useQuery } from 'urql'
 
 const ProductsQuery = `
-query ($query: String!, $sortKey: ProductSortKeys, $count: Int!) {
-   products( query: $query, sortKey: $sortKey, first: $count) {
-      edges {
-        node {
-          title
-          vendor
-          productType
-          handle
-          priceRangeV2: priceRange {
-            minVariantPrice {
-              currencyCode
-              amount
-            }
-            maxVariantPrice {
-              currencyCode
-              amount
-            }
+query ($query: String!, $sortKey: ProductSortKeys, $count: Int!, $after: String, $before: String) {
+  products(
+    query: $query
+    sortKey: $sortKey
+    first: $count
+    after: $after
+    before: $before
+  ) {
+    pageInfo {
+      hasNextPage
+      hasPreviousPage
+    }
+    edges {
+      cursor
+      node {
+        title
+        vendor
+        productType
+        handle
+        priceRangeV2: priceRange {
+          minVariantPrice {
+            currencyCode
+            amount
           }
-          id
-          images(first: 1) {
-            edges {
-              node {
-                originalSrc
-                width
-                height
-                altText
-              }
+          maxVariantPrice {
+            currencyCode
+            amount
+          }
+        }
+        id
+        images(first: 1) {
+          edges {
+            node {
+              originalSrc
+              width
+              height
+              altText
             }
           }
         }
       }
     }
   }
+}
+
 `
 
 function makeFilter(field, allItems, selectedItems) {
@@ -61,7 +73,9 @@ export function useProductSearch(
   },
   sortKey,
   pause = false,
-  count = 20
+  count = 20,
+  after,
+  before
 ) {
   const [query, setQuery] = useState('')
 
@@ -95,7 +109,7 @@ export function useProductSearch(
 
   return useQuery({
     query: ProductsQuery,
-    variables: { query, sortKey, count },
+    variables: { query, sortKey, count, after, before },
     pause,
   })
 }

--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -104,8 +104,8 @@ export function useProductSearch(
 ) {
   const [query, setQuery] = useState('')
 
-  // Relevance is non-deterministic if there is no query, so we default to "trending" instead
-  const initialSortKey = term ? 'RELEVANCE' : 'BEST_SELLING'
+  // Relevance is non-deterministic if there is no query, so we default to "title" instead
+  const initialSortKey = term ? 'RELEVANCE' : 'TITLE'
 
   useEffect(() => {
     const parts = [
@@ -153,6 +153,7 @@ export function useProductSearch(
     selectedVendors,
     minPrice,
     maxPrice,
+    sortKey,
   ])
 
   return useQuery({


### PR DESCRIPTION
Because Shopify does cursor-based pagination we can't show all the pages until we've visited them, so initially we just show the "next" button, but once we've navigated we can record the cursor for each page and then jump to them as needed.

![image](https://user-images.githubusercontent.com/213306/114701269-7f934300-9d1a-11eb-825a-25e169eda4fc.png)


[ch28853]