### PR TITLE
Default filters to unchecked

### DIFF
--- a/src/pages/search.jsx
+++ b/src/pages/search.jsx
@@ -74,21 +74,19 @@ export default function SearchPage({
 
   const [searchTerm, setSearchTerm] = React.useState(queryParams.term)
 
-  const [minPrice, setMinPrice] = React.useState(queryParams.term)
-  const [maxPrice, setMaxPrice] = React.useState("")
+  const [minPrice, setMinPrice] = React.useState(queryParams.minPrice)
+  const [maxPrice, setMaxPrice] = React.useState(queryParams.maxPrice)
 
   const [sortKey, setSortKey] = React.useState(queryParams.sortKey)
 
-  const [selectedTags, setSelectedTags] = React.useState(
-    queryParams.tags || tags
-  )
+  const [selectedTags, setSelectedTags] = React.useState(queryParams.tags)
 
   const [selectedVendors, setSelectedVendors] = React.useState(
-    queryParams.vendors || vendors
+    queryParams.vendors
   )
 
   const [selectedProductTypes, setSelectedProductTypes] = React.useState(
-    queryParams.productTypes || productTypes
+    queryParams.productTypes
   )
 
   const [cursor, setCursor] = React.useState(-1)

--- a/src/utils/format-price.js
+++ b/src/utils/format-price.js
@@ -15,7 +15,6 @@ export const getCurrencySymbol = (currency, locale = undefined) => {
   if (!currency) {
     return
   }
-  console.log({ currency })
   const formatter = Intl.NumberFormat(locale, {
     currency,
     style: "currency",

--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -70,6 +70,16 @@ function makeQueryStringValue(allItems, selectedItems) {
   return selectedItems
 }
 
+function arrayify(value) {
+  if (!value) {
+    return []
+  }
+  if (!Array.isArray(value)) {
+    return [value]
+  }
+  return value
+}
+
 /**
  * Extracts default search values from the query string
  * @param {string} query
@@ -78,13 +88,21 @@ export function getValuesFromQueryString(query) {
   const {
     q: term,
     s: sortKey,
-    p: productTypes,
-    t: tags,
-    v: vendors,
     x: maxPrice,
     n: minPrice,
+    p,
+    t,
+    v,
   } = queryString.parse(query)
-  return { term, sortKey, productTypes, tags, vendors, maxPrice, minPrice }
+  return {
+    term,
+    sortKey,
+    maxPrice,
+    minPrice,
+    productTypes: arrayify(p),
+    tags: arrayify(t),
+    vendors: arrayify(v),
+  }
 }
 
 export function useProductSearch(


### PR DESCRIPTION
On the search page, defaults the filters to unchecked. The behaviour is the same (because none checked means unfiltered), but it makes it easier to add individual filters.