### PR TITLE
Fix "Sort by" `:focus` state

### DIFF
--- a/src/pages/search-page.module.css
+++ b/src/pages/search-page.module.css
@@ -63,6 +63,11 @@
   padding-right: var(--size-2xl);
 }
 
+.sortSelector > label,
+.sortSelector > label > select {
+  cursor: pointer;
+}
+
 .productList {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));

--- a/src/pages/search.jsx
+++ b/src/pages/search.jsx
@@ -176,19 +176,21 @@ export default function SearchPage({
             placeholder="Search..."
           />
           <div className={sortSelector}>
-            Sort by{" "}
-            <select
-              name="sort"
-              id="sort"
-              value={sortKey}
-              onBlur={(e) => setSortKey(e.target.value)}
-            >
-              <option value="RELEVANCE">Relevance</option>
-              <option value="PRICE">Price</option>
-              <option value="TITLE">Title</option>
-              <option value="CREATED_AT">New items</option>
-              <option value="BEST_SELLING">Trending</option>
-            </select>
+            <label for="sort">
+              Sort by{" "}
+              <select
+                name="sort"
+                id="sort"
+                value={sortKey}
+                onBlur={(e) => setSortKey(e.target.value)}
+              >
+                <option value="RELEVANCE">Relevance</option>
+                <option value="PRICE">Price</option>
+                <option value="TITLE">Title</option>
+                <option value="CREATED_AT">New items</option>
+                <option value="BEST_SELLING">Trending</option>
+              </select>
+            </label>
           </div>
         </div>
         <section className={filters}>

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -10,7 +10,7 @@ html {
 body {
   position: relative;
   min-height: 100%;
-  font-feature-settings: 'kern';
+  font-feature-settings: "kern";
 }
 *,
 *::before,
@@ -88,9 +88,9 @@ select {
   text-transform: none;
 }
 button::-moz-focus-inner,
-[type='button']::-moz-focus-inner,
-[type='reset']::-moz-focus-inner,
-[type='submit']::-moz-focus-inner {
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner {
   border-style: none;
   padding: 0;
 }
@@ -111,23 +111,23 @@ progress {
 textarea {
   overflow: auto;
 }
-[type='checkbox'],
-[type='radio'] {
+[type="checkbox"],
+[type="radio"] {
   box-sizing: border-box;
   padding: 0;
 }
-[type='number']::-webkit-inner-spin-button,
-[type='number']::-webkit-outer-spin-button {
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
   -webkit-appearance: none !important;
 }
-input[type='number'] {
+input[type="number"] {
   -moz-appearance: textfield;
 }
-[type='search'] {
+[type="search"] {
   -webkit-appearance: textfield;
   outline-offset: -2px;
 }
-[type='search']::-webkit-search-decoration {
+[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none !important;
 }
 ::-webkit-file-upload-button {
@@ -179,7 +179,7 @@ textarea {
   resize: vertical;
 }
 button,
-[role='button'] {
+[role="button"] {
   cursor: pointer;
 }
 button::-moz-focus-inner {
@@ -220,10 +220,6 @@ img,
 video {
   max-width: 100%;
   height: auto;
-}
-[data-js-focus-visible] :focus:not([data-focus-visible-added]) {
-  outline: none;
-  box-shadow: none;
 }
 select::-ms-expand {
   display: none;


### PR DESCRIPTION
Noticed that the "Sort by" `<select>` doesn't show a `:focus` outline — removing a rule in `reset.css` fixed that.

Also wrapped the `<select>` in a `<label>`, and gave both a `cursor: pointer` — always feeling icky when doing so, but IMO it helps 🤷‍♂️

![image](https://user-images.githubusercontent.com/21834/115705078-6159c280-a36c-11eb-8d94-44645274f7b7.png)
