### PR TITLE
Move urql context into just search page

### DIFF
--- a/src/context/search-provider.jsx
+++ b/src/context/search-provider.jsx
@@ -1,0 +1,16 @@
+import * as React from "react"
+import { createClient, Provider as UrlqProvider } from "urql"
+
+const urqlClient = createClient({
+  url: `https://${process.env.GATSBY_SHOPIFY_STORE_URL}/api/2021-01/graphql.json`,
+  fetchOptions: {
+    headers: {
+      "X-Shopify-Storefront-Access-Token":
+        process.env.GATSBY_STOREFRONT_ACCESS_TOKEN,
+    },
+  },
+})
+
+export function SearchProvider({ children }) {
+  return <UrlqProvider value={urqlClient}>{children}</UrlqProvider>
+}

--- a/src/context/store-context.jsx
+++ b/src/context/store-context.jsx
@@ -1,18 +1,6 @@
-import fetch from "isomorphic-fetch"
 import * as React from "react"
+import fetch from "isomorphic-fetch"
 import Client from "shopify-buy"
-
-import { createClient, Provider as UrlqProvider } from "urql"
-
-const urqlClient = createClient({
-  url: `https://${process.env.GATSBY_SHOPIFY_STORE_URL}/api/2021-01/graphql.json`,
-  fetchOptions: {
-    headers: {
-      "X-Shopify-Storefront-Access-Token":
-        process.env.GATSBY_STOREFRONT_ACCESS_TOKEN,
-    },
-  },
-})
 
 const client = Client.buildClient(
   {
@@ -133,20 +121,18 @@ export const StoreProvider = ({ children }) => {
   }
 
   return (
-    <UrlqProvider value={urqlClient}>
-      <StoreContext.Provider
-        value={{
-          ...defaultValues,
-          addVariantToCart,
-          removeLineItem,
-          updateLineItem,
-          checkout,
-          loading,
-          didJustAddToCart,
-        }}
-      >
-        {children}
-      </StoreContext.Provider>
-    </UrlqProvider>
+    <StoreContext.Provider
+      value={{
+        ...defaultValues,
+        addVariantToCart,
+        removeLineItem,
+        updateLineItem,
+        checkout,
+        loading,
+        didJustAddToCart,
+      }}
+    >
+      {children}
+    </StoreContext.Provider>
   )
 }

--- a/src/pages/search.jsx
+++ b/src/pages/search.jsx
@@ -41,6 +41,7 @@ import {
 import { getCurrencySymbol } from "../utils/format-price"
 import { Spinner } from "../components/progress"
 import { Filters } from "../components/filters"
+import { SearchProvider } from "../context/search-provider"
 
 export const query = graphql`
   query {
@@ -76,7 +77,7 @@ export const query = graphql`
   }
 `
 
-export default function SearchPage({
+function SearchPage({
   data: {
     meta: { productTypes, vendors, tags },
     products,
@@ -314,5 +315,13 @@ export default function SearchPage({
         </section>
       </div>
     </Layout>
+  )
+}
+
+export default function SearchPageTemplate(props) {
+  return (
+    <SearchProvider>
+      <SearchPage {...props} />
+    </SearchProvider>
   )
 }


### PR DESCRIPTION
Hopefully improve bundle size by moving urql provider so it is only used for search page

Edit: confirmed. App bundle drops from [143kB](https://build-06e6e9b5-48ae-4259-a3ef-a50e4dafadb4.gtsb.io/app-e538a45e1fbfe2e3ec47.js) to [82kB](https://shopify30k-urqlshake.gtsb.io/app-ec5b2ef96313311d1eb6.js)